### PR TITLE
Update tex-parser.ts tokenize()

### DIFF
--- a/src/tex-parser.ts
+++ b/src/tex-parser.ts
@@ -240,7 +240,7 @@ export function tokenize(latex: string): TexToken[] {
                     token = new TexToken(TexTokenType.ELEMENT, latex.slice(pos, newPos));
                 } else if (isalpha(firstChar)) {
                     token = new TexToken(TexTokenType.ELEMENT, firstChar);
-                } else if ('+-*/=\'<>!.,;?()[]|'.includes(firstChar)) {
+                } else if ('+-*/=\'<>!.,;:?()[]|'.includes(firstChar)) {
                     token = new TexToken(TexTokenType.ELEMENT, firstChar)
                 } else {
                     token = new TexToken(TexTokenType.UNKNOWN, firstChar);


### PR DESCRIPTION
add `:` to the `tokenize()` function, so that `:` will not get parsed as unkown token.