### PR TITLE
Add support for cases

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -274,7 +274,7 @@ export function convert_tex_node_to_typst(node: TexNode, options: Tex2TypstOptio
                 // align, align*, alignat, alignat*, aligned, etc.
                 return new TypstNode('align', '', [], data);
             }
-            if (node.content!.startsWith('cases')) {
+            if (node.content! === 'cases') {
                 return new TypstNode('cases', '', [], data);
             }
             if (node.content!.endsWith('matrix')) {

--- a/src/convert.ts
+++ b/src/convert.ts
@@ -274,6 +274,9 @@ export function convert_tex_node_to_typst(node: TexNode, options: Tex2TypstOptio
                 // align, align*, alignat, alignat*, aligned, etc.
                 return new TypstNode('align', '', [], data);
             }
+            if (node.content!.startsWith('cases')) {
+                return new TypstNode('cases', '', [], data);
+            }
             if (node.content!.endsWith('matrix')) {
                 let delim: TypstPrimitiveValue = null;
                 switch (node.content) {
@@ -515,6 +518,11 @@ export function convert_typst_node_to_tex(node: TypstNode): TexNode {
                 matrix,
                 new TexNode('element', right_delim)
             ]);
+        }
+        case 'cases': {
+            const typst_data = node.data as TypstNode[][];
+            const tex_data = typst_data.map(row => row.map(convert_typst_node_to_tex));
+            return new TexNode('beginend', 'cases', [], tex_data);
         }
         case 'control': {
             switch (node.content) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,7 +350,7 @@ export interface TypstSupsubData {
 export type TypstArrayData = TypstNode[][];
 
 type TypstNodeType = 'atom' | 'symbol' | 'text' | 'control' | 'comment' | 'whitespace'
-            | 'empty' | 'group' | 'supsub' | 'funcCall' | 'fraction' | 'align' | 'matrix' | 'unknown';
+            | 'empty' | 'group' | 'supsub' | 'funcCall' | 'fraction' | 'align' | 'matrix' | 'cases' | 'unknown';
 
 export type TypstPrimitiveValue = string | boolean | null | TypstToken;
 export type TypstNamedParams = { [key: string]: TypstPrimitiveValue };

--- a/src/typst-parser.ts
+++ b/src/typst-parser.ts
@@ -383,6 +383,12 @@ export class TypstParser {
                     mat.setOptions(named_params);
                     return [mat, newPos];
                 }
+                if(firstToken.value === 'cases') {
+                    const [cases, named_params, newPos] = this.parseGroupsOfArguments(tokens, start + 1, COMMA);
+                    const casesNode = new TypstNode('cases', '', [], cases);
+                    casesNode.setOptions(named_params);
+                    return [casesNode, newPos];
+                }
                 const [args, newPos] = this.parseArguments(tokens, start + 1);
                 const func_call = new TypstNode('funcCall', firstToken.value);
                 func_call.args = args;
@@ -400,7 +406,7 @@ export class TypstParser {
     }
 
     // start: the position of the left parentheses
-    parseGroupsOfArguments(tokens: TypstToken[], start: number): [TypstNode[][], TypstNamedParams, number] {
+    parseGroupsOfArguments(tokens: TypstToken[], start: number, newline_token = SEMICOLON): [TypstNode[][], TypstNamedParams, number] {
         const end = find_closing_match(tokens, start);
         tokens = tokens.slice(0, end);
 
@@ -410,7 +416,7 @@ export class TypstParser {
         let pos = start + 1;
         while (pos < end) {
             while(pos < end) {
-                let next_stop = array_find(tokens, SEMICOLON, pos);
+                let next_stop = array_find(tokens, newline_token, pos);
                 if (next_stop === -1) {
                     next_stop = end;
                 }

--- a/src/typst-writer.ts
+++ b/src/typst-writer.ts
@@ -275,6 +275,33 @@ export class TypstWriter {
                 this.insideFunctionDepth--;
                 break;
             }
+            case 'cases': {
+                const cases = node.data as TypstNode[][];
+                this.queue.push(new TypstToken(TypstTokenType.SYMBOL, 'cases'));
+                this.insideFunctionDepth++;
+                this.queue.push(TYPST_LEFT_PARENTHESIS);
+                if (node.options) {
+                    for (const [key, value] of Object.entries(node.options)) {
+                        const value_str = typst_primitive_to_string(value);
+                        this.queue.push(new TypstToken(TypstTokenType.SYMBOL, `${key}: ${value_str}, `));
+                    }
+                }
+                cases.forEach((row, i) => {
+                    row.forEach((cell, j) => {
+                        this.serialize(cell);
+                        if (j < row.length - 1) {
+                            this.queue.push(new TypstToken(TypstTokenType.ELEMENT, '&'));
+                        } else {
+                            if (i < cases.length - 1) {
+                                this.queue.push(new TypstToken(TypstTokenType.ELEMENT, ','));
+                            }
+                        }
+                    });
+                });
+                this.queue.push(TYPST_RIGHT_PARENTHESIS);
+                this.insideFunctionDepth--;
+                break;
+            }
             case 'unknown': {
                 if (this.nonStrict) {
                     this.queue.push(new TypstToken(TypstTokenType.SYMBOL, node.content));

--- a/test/integration-cases.yml
+++ b/test/integration-cases.yml
@@ -431,4 +431,69 @@ cases:
   - title: "<-->"
     tex: a \longleftrightarrow b
     typst: a <--> b
-  
+  - title: cases1
+    tex: |-
+      \begin{cases}
+      x^2, & \text{if } x \ge 0 \\
+      - x, & \text{if } x < 0
+      \end{cases}
+    typst: |-
+      cases(x^2 comma & "if " x >= 0,
+      - x comma & "if " x < 0)
+  - title: cases2
+    tex: |-
+      A_{i j} =
+      \begin{cases}
+      1, & \text{if } i = j \\
+      0, & \text{otherwise}
+      \end{cases}
+    typst: |-
+      A_(i j) =
+      cases(1 comma & "if " i = j,
+      0 comma & "otherwise")
+  - title: cases3
+    tex: |-
+      P(X = x) =
+      \begin{cases}
+      n, & x \in\{1, 2, \dots, n\} \\
+      0, & \text{otherwise}
+      \end{cases}
+    typst: |-
+      P(X = x) =
+      cases(n comma & x in {1 comma 2 comma ... comma n},
+      0 comma & "otherwise")
+  - title: cases4
+    tex: |-
+      f(x) =
+      \begin{cases}
+      x^2 + 1, & \text{if } x < - 1 \\
+      \sin x + x^2, & \text{if } - 1 \le x \le 1 \\
+      \sqrt{x}, & \text{if } x > 1
+      \end{cases}
+    typst: |-
+      f(x) =
+      cases(x^2 + 1 comma & "if " x < - 1,
+      sin x + x^2 comma & "if " - 1 <= x <= 1,
+      sqrt(x) comma & "if " x > 1)
+  - title: cases5
+    tex: |-
+      \begin{aligned}
+      f(x) &=
+      \begin{cases}
+      x^2, & x \ge 0 \\
+      - x, & x < 0
+      \end{cases} \\
+      g(x) &=
+      \begin{cases}
+      \sin x, & x < \pi \\
+      0, & x \ge \pi
+      \end{cases}
+      \end{aligned}
+
+    typst: |-
+      f(x) &=
+      cases(x^2 comma & x >= 0,
+      - x comma & x < 0) \
+      g(x) &=
+      cases(sin x comma & x < pi,
+      0 comma & x >= pi)

--- a/test/math.yml
+++ b/test/math.yml
@@ -386,3 +386,69 @@ cases:
   - title: hspace
     tex: \hspace{1cm}
     typst: "#h(1cm)"
+  - title: cases1
+    tex: |-
+      \begin{cases}
+      x^2, & \text{if } x \geq 0 \\
+      -x,  & \text{if } x < 0
+      \end{cases}
+    typst: |-
+      cases(x^2 comma & "if " x >= 0,
+      - x comma & "if " x < 0)
+  - title: cases2
+    tex: |-
+      A_{ij} = 
+        \begin{cases}
+        1, & \text{if } i = j \\
+        0, & \text{otherwise}
+        \end{cases}
+    typst: |-
+      A_(i j) =
+      cases(1 comma & "if " i = j,
+      0 comma & "otherwise")
+  - title: cases3
+    tex: |-
+      P(X = x) = 
+        \begin{cases}
+        \frac{1}{n}, & x \in \{1,2,\dots,n\} \\
+        0,           & \text{otherwise}
+        \end{cases}
+    typst: |-
+      P(X = x) =
+      cases(1/n comma & x in {1 comma 2 comma ... comma n},
+      0 comma & "otherwise")
+  - title: cases4
+    tex: |-
+      f(x) = 
+        \begin{cases}
+        x^2 + 1,        & \text{if } x < -1 \\
+        \sin x + x^2,   & \text{if } -1 \leq x \leq 1 \\
+        \sqrt{x},       & \text{if } x > 1
+        \end{cases}
+    typst: |-
+      f(x) =
+      cases(x^2 + 1 comma & "if " x < - 1,
+      sin x + x^2 comma & "if " - 1 <= x <= 1,
+      sqrt(x) comma & "if " x > 1)
+  - title: cases5
+    tex: |-
+      \begin{align*}
+      f(x) &= 
+      \begin{cases}
+      x^2, & x \geq 0 \\
+      -x, & x < 0
+      \end{cases} \\
+      g(x) &= 
+      \begin{cases}
+      \sin x, & x < \pi \\
+      0, & x \geq \pi
+      \end{cases}
+      \end{align*}
+
+    typst: |-
+      f(x) &=
+      cases(x^2 comma & x >= 0,
+      - x comma & x < 0) \
+      g(x) &=
+      cases(sin x comma & x < pi,
+      0 comma & x >= pi)


### PR DESCRIPTION
Added support for cases, enabling mutual conversion between LaTeX and Typst code like the examples below:

```latex
f(x) = 
        \begin{cases}
        x^2 + 1,        & \text{if } x < -1 \\
        \sin x + x^2,   & \text{if } -1 \leq x \leq 1 \\
        \sqrt{x},       & \text{if } x > 1
        \end{cases}
```

```typm
f(x) =
      cases(x^2 + 1 comma & "if " x < - 1,
      sin x + x^2 comma & "if " - 1 <= x <= 1,
      sqrt(x) comma & "if " x > 1)
```

Since many parameters in Typst’s cases function are not supported in LaTeX’s cases environment, the parameters of Typst's cases function are not handled.

Added several test cases for both LaTeX-to-Typst and Typst-to-LaTeX conversion.