### PR TITLE
Add Support for \bigl, \bigr, \biggl, and \biggr as Paired Delimiter Commands

### DIFF
--- a/src/tex-parser.ts
+++ b/src/tex-parser.ts
@@ -48,7 +48,12 @@ const BINARY_COMMANDS = [
     'overset',
 ]
 
-
+const IGNORED_COMMANDS = [
+    'bigl', 'bigr',
+    'biggl', 'biggr',
+    'Bigl', 'Bigr',
+    'Biggl', 'Biggr',
+];
 
 const EMPTY_NODE: TexNode = new TexNode('empty', '');
 
@@ -296,6 +301,9 @@ export class LatexParser {
     }
 
     parseNextExprWithoutSupSub(tokens: TexToken[], start: number): ParseResult {
+        if (start >= tokens.length) {
+            return [EMPTY_NODE, start];
+        }
         const firstToken = tokens[start];
         switch (firstToken.type) {
             case TexTokenType.ELEMENT:
@@ -308,6 +316,10 @@ export class LatexParser {
             case TexTokenType.NEWLINE:
                 return [new TexNode('whitespace', firstToken.value), start + 1];
             case TexTokenType.COMMAND:
+                const commandName = firstToken.value.slice(1);
+                if (IGNORED_COMMANDS.includes(commandName)) {
+                    return this.parseNextExprWithoutSupSub(tokens, start + 1);
+                }
                 if (firstToken.eq(BEGIN_COMMAND)) {
                     return this.parseBeginEndExpr(tokens, start);
                 } else if (firstToken.eq(LEFT_COMMAND)) {

--- a/src/tex-parser.ts
+++ b/src/tex-parser.ts
@@ -127,9 +127,12 @@ const LEFT_RIGHT_COMMANDS: TexToken[][] = [
     [
         new TexToken(TexTokenType.COMMAND, '\\bigl'),
         new TexToken(TexTokenType.COMMAND, '\\bigr'),
+    ],
+    [
+        new TexToken(TexTokenType.COMMAND, '\\biggl'),
+        new TexToken(TexTokenType.COMMAND, '\\biggr'),
     ]
 ]
-const RIGHT_COMMAND: TexToken = new TexToken(TexTokenType.COMMAND, '\\right');
 
 function find_closing_right_command(tokens: TexToken[], start: number): number {
     const leftCommand = tokens[start];
@@ -417,36 +420,38 @@ export class LatexParser {
     }
 
     parseLeftRightExpr(tokens: TexToken[], start: number): ParseResult {
-        assert(LEFT_RIGHT_COMMANDS.some(pair => tokens[start].eq(pair[0])));
+        const pairs = LEFT_RIGHT_COMMANDS.filter(pair => tokens[start].eq(pair[0]));
+        assert(pairs.length > 0);
+        const [leftCommand, rightCommand] = pairs[0];
 
         let pos = start + 1;
         pos += eat_whitespaces(tokens, pos).length;
 
         if (pos >= tokens.length) {
-            throw new LatexParserError('Expecting delimiter after \\left');
+            throw new LatexParserError(`Expecting delimiter after ${leftCommand.value}`);
         }
 
         const leftDelimiter = eat_parenthesis(tokens, pos);
         if (leftDelimiter === null) {
-            throw new LatexParserError('Invalid delimiter after \\left');
+            throw new LatexParserError(`Invalid delimiter after ${leftCommand.value}`);
         }
         pos++;
         const exprInsideStart = pos;
         const idx = find_closing_right_command(tokens, start);
         if (idx === -1) {
-            throw new LatexParserError('No matching \\right');
+            throw new LatexParserError(`No matching ${rightCommand.value}`);
         }
         const exprInsideEnd = idx;
         pos = idx + 1;
 
         pos += eat_whitespaces(tokens, pos).length;
         if (pos >= tokens.length) {
-            throw new LatexParserError('Expecting \\right after \\left');
+            throw new LatexParserError(`Expecting ${rightCommand.value} after ${leftCommand.value}`);
         }
 
         const rightDelimiter = eat_parenthesis(tokens, pos);
         if (rightDelimiter === null) {
-            throw new LatexParserError('Invalid delimiter after \\right');
+            throw new LatexParserError(`Invalid delimiter after ${rightCommand.value}`);
         }
         pos++;
 

--- a/test/math.yml
+++ b/test/math.yml
@@ -47,24 +47,9 @@ cases:
   - title: lr
     tex: \left|a + \frac{1}{3} \right|^2
     typst: lr(|a + 1/3|)^2
-  - title: biglr
-    tex: \bigl|a + \frac{1}{3} \bigr|^2
-    typst: lr(|a + 1/3|)^2
-  - title: bigglr
-    tex: \biggl|a + \frac{1}{3} \biggr|^2
-    typst: lr(|a + 1/3|)^2
   - title: symmetry left right
     tex: \left\{ a \right\} \left( b \right) \left[ c \right]
     typst: '{a}(b) [c]'
-  - title: symmetry bigl bigr
-    tex: \bigl\{ a \bigr\} \bigl( b \bigr) \bigl[ c \bigr]
-    typst: '{a}(b) [c]'
-  - title: symmetry biggl biggr
-    tex: \biggl\{ a \biggr\} \biggl( b \biggr) \biggl[ c \biggr]
-    typst: '{a}(b) [c]'
-  - title: paired delimiter commands
-    tex: \left(\bigl[\biggl\{a\biggr\}\bigr]\right)
-    typst: '([ {a}])'
   - title: operatorname
     tex: '\operatorname{diag} \text{diag}'
     typst: 'op("diag") "diag"'

--- a/test/math.yml
+++ b/test/math.yml
@@ -47,8 +47,14 @@ cases:
   - title: lr
     tex: \left|a + \frac{1}{3} \right|^2
     typst: lr(|a + 1/3|)^2
+  - title: biglr
+    tex: \bigl|a + \frac{1}{3} \bigr|^2
+    typst: lr(|a + 1/3|)^2
   - title: symmetry left right
     tex: \left\{ a \right\} \left( b \right) \left[ c \right]
+    typst: '{a}(b) [c]'
+  - title: symmetry bigl bigr
+    tex: \bigl\{ a \bigr\} \bigl( b \bigr) \bigl[ c \bigr]
     typst: '{a}(b) [c]'
   - title: operatorname
     tex: '\operatorname{diag} \text{diag}'

--- a/test/math.yml
+++ b/test/math.yml
@@ -47,9 +47,27 @@ cases:
   - title: lr
     tex: \left|a + \frac{1}{3} \right|^2
     typst: lr(|a + 1/3|)^2
+  - title: biglr
+    tex: \bigl|a + \frac{1}{3} \bigr|^2
+    typst: "|a + 1/3|^2"
+  - title: bigglr
+    tex: \biggl|a + \frac{1}{3} \biggr|^2
+    typst: "|a + 1/3|^2"
   - title: symmetry left right
     tex: \left\{ a \right\} \left( b \right) \left[ c \right]
     typst: '{a}(b) [c]'
+  - title: symmetry bigl bigr
+    tex: \bigl\{ a \bigr\} \bigl( b \bigr) \bigl[ c \bigr]
+    typst: '{a}(b) [c]'
+  - title: symmetry biggl biggr
+    tex: \biggl\{ a \biggr\} \biggl( b \biggr) \biggl[ c \biggr]
+    typst: '{a}(b) [c]'
+  - title: symmetry Biggl Biggr
+    tex: \Biggl\{ a \Biggr\} \Biggl( b \Biggr) \Biggl[ c \Biggr]
+    typst: '{a}(b) [c]'
+  - title: paired delimiter commands
+    tex: \left(\bigl[\biggl\{a\biggr\}\bigr]\right)
+    typst: '([ {a}])'
   - title: operatorname
     tex: '\operatorname{diag} \text{diag}'
     typst: 'op("diag") "diag"'

--- a/test/math.yml
+++ b/test/math.yml
@@ -50,12 +50,21 @@ cases:
   - title: biglr
     tex: \bigl|a + \frac{1}{3} \bigr|^2
     typst: lr(|a + 1/3|)^2
+  - title: bigglr
+    tex: \biggl|a + \frac{1}{3} \biggr|^2
+    typst: lr(|a + 1/3|)^2
   - title: symmetry left right
     tex: \left\{ a \right\} \left( b \right) \left[ c \right]
     typst: '{a}(b) [c]'
   - title: symmetry bigl bigr
     tex: \bigl\{ a \bigr\} \bigl( b \bigr) \bigl[ c \bigr]
     typst: '{a}(b) [c]'
+  - title: symmetry biggl biggr
+    tex: \biggl\{ a \biggr\} \biggl( b \biggr) \biggl[ c \biggr]
+    typst: '{a}(b) [c]'
+  - title: paired delimiter commands
+    tex: \left(\bigl[\biggl\{a\biggr\}\bigr]\right)
+    typst: '([ {a}])'
   - title: operatorname
     tex: '\operatorname{diag} \text{diag}'
     typst: 'op("diag") "diag"'


### PR DESCRIPTION
This PR extends the paired delimiter matching logic to support additional LaTeX commands commonly used for scalable delimiters.

1. `\bigl` ↔` \bigr`
2. `\biggl` ↔ `\biggr`

Since Typst automatically adjusts bracket sizes based on context, the visual size hints in \bigl, \bigr, \biggl, and \biggr are intentionally ignored during conversion. This simplifies the implementation.