### PR TITLE
Add support for substack and subarray

### DIFF
--- a/src/convert.ts
+++ b/src/convert.ts
@@ -290,6 +290,15 @@ export function convert_tex_node_to_typst(node: TexNode, options: Tex2TypstOptio
                 );
             }
 
+            if (node.content === '\\substack') {
+                // \sum_{\substack{a \\ b}} -> sum_(a \ b)
+                return new TypstNode(
+                    'group',
+                    '',
+                    [arg0]
+                );
+            }
+
             if(options.optimize) {
                 // \mathbb{R} -> RR
                 if (node.content === '\\mathbb' && arg0.type === 'atom' && /^[A-Z]$/.test(arg0.content)) {
@@ -318,6 +327,21 @@ export function convert_tex_node_to_typst(node: TexNode, options: Tex2TypstOptio
             }
             if (node.content! === 'cases') {
                 return new TypstNode('cases', '', [], data);
+            }
+            if (node.content! === 'subarray') {
+                console.log(node);
+                const align_node = node.args![0];
+                if (align_node.content == 'r') {
+                    data.forEach(row => row[0].args!.push(new TypstNode('symbol', '&')));
+                }
+                if (align_node.content == 'l') {
+                    data.forEach(row => row[0].args!.unshift(new TypstNode('symbol', '&')));
+                }
+                return new TypstNode(
+                    'group',
+                    '',
+                    [new TypstNode('align', '', [], data)]
+                );
             }
             if (node.content! === 'array') {
                 const res = new TypstNode('matrix', '', [], data);

--- a/src/tex-tokenizer.ts
+++ b/src/tex-tokenizer.ts
@@ -35,6 +35,7 @@ export const TEX_UNARY_COMMANDS = [
     'overleftarrow',
     'overrightarrow',
     'hspace',
+    'substack',
 ]
 
 export const TEX_BINARY_COMMANDS = [

--- a/test/struct-tex2typst.yaml
+++ b/test/struct-tex2typst.yaml
@@ -406,3 +406,18 @@ cases:
   - title: parenthesis in fraction
     tex: C \frac{xy}{z}
     typst: C (x y)/z
+  - title: substack
+    tex: \sum_{\substack{0 \leq i \leq m \\ 0 < j < n}} P(i, j)
+    typst: sum_(0 <= i <= m \ 0 < j < n) P(i, j)
+  - title: subarray-l
+    tex: \sum_{\begin{subarray}{l} 0 \leq i \leq m \\ 0 < j < n \end{subarray}} P(i, j)
+    typst: sum_(& 0 <= i <= m \ & 0 < j < n) P(i, j)
+  - title: subarray
+    tex: \sum_{\begin{subarray}{c} 0 \leq i \leq m \\ 0 < j < n \end{subarray}} P(i, j)
+    typst: sum_(0 <= i <= m \ 0 < j < n) P(i, j)
+  - title: subarray-r
+    tex: \sum_{\begin{subarray}{r} 0 \leq i \leq m \\ 0 < j < n \end{subarray}} P(i, j)
+    typst: sum_(0 <= i <= m & \ 0 < j < n &) P(i, j)
+  - title: subarray-with-rr &
+    tex: \sum_{\begin{subarray}{rr} a & b \\ c & d \end{subarray}} P(i, j)
+    typst: sum_(a & b \ c & d) P(i, j)


### PR DESCRIPTION
Actually, this PR's simulation of subarray behavior is not complete. The reason is that Typst's `linebreak` and `&` do not have any means to specify alignment methods. If we use mat to simulate this behavior, the display style will change (mat will make sub or sup smaller).

Maybe looking for an alternative via the typst package is an option