### PR TITLE
Refactor LatexParser to simplify \displaystyle handling

### DIFF
--- a/tests/struct-tex2typst.yaml
+++ b/tests/struct-tex2typst.yaml
@@ -449,3 +449,6 @@ cases:
   - title: command mathinner is ignored
     tex: ab\mathinner{\text{inside}}cd
     typst: a b "inside" c d
+  - title: vector with overHigh
+    tex: \left( \displaystyle \vec{X} \right)
+    typst: (display(arrow(X)))


### PR DESCRIPTION
now parses token streams without the fragile upfront split on `\displaystyle`. After each closure is built the new applyStyleCommands/getStyleToken helpers wrap any standalone `\displaystyle/\textstyle` terminals into proper `TexFuncCall` nodes that consume the remaining items inside the current group, so constructs like `\left( \displaystyle … \right)` keep their delimiters balanced.